### PR TITLE
Add spark installation + hive on spark configuration properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Files: [./conf/target-aws.xml] (./conf/target-aws.xml) and [./conf/target-common
   * Destroy instances by 'destroy-aws' command after they are not needed anymore.
 * The scope of nodes that are accessed these AWS command is limited to nodes owned by you in the specified AWS region (to improve performance).
   * Be careful, you may have had created instances in a regions that are not listed by the tool if it is pointing to another region.
+* The cluster comes with an already configured hadoop and hive environment, as well as a spark installation. This allows the user to specify Spark as execution engine for Hive.
+To do so, the properties related to Spark in the `hadoop-resources/hadoop-conf/cluster-default/hive/conf/hive-site.xml` configuration should be uncommented.
 
 
 ##### Operation List

--- a/hadoop-resources/hadoop-conf/cluster-default/hive/conf/hive-site.xml
+++ b/hadoop-resources/hadoop-conf/cluster-default/hive/conf/hive-site.xml
@@ -69,4 +69,39 @@
     <description>IP address (or fully-qualified domain name) and port of the metastore host</description>
   </property>
 
+
+  <!-- The following properties are to be uncommented when using Hive on spark (Hive with Spark as execution engine)
+  <property>
+    <name>hive.execution.engine</name>
+    <value>spark</value>
+  </property>
+
+  <property>
+    <name>hive.enable.spark.execution.engine</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>spark.eventLog.enabled</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>spark.eventLog.dir</name>
+    <value>hdfs:///user/spark/applicationHistory</value>
+  </property>
+
+  <property>
+    <name>spark.serializer</name>
+    <value>org.apache.spark.serializer.KryoSerializer</value>
+  </property>
+
+  <property>
+    <name>spark.master</name>
+    <value>yarn</value>
+  </property>
+
+  -->
+
+
 </configuration>

--- a/hadoop-resources/setup-scripts/start/start-master.sh
+++ b/hadoop-resources/setup-scripts/start/start-master.sh
@@ -29,3 +29,7 @@ sudo service hadoop-mapreduce-historyserver restart
 #Start Hive metastore
 sudo service mysql restart
 sudo service hive-metastore restart
+
+#Spark history server
+sudo hdfs dfs -mkdir -p hdfs:///user/spark/applicationHistory
+sudo hdfs dfs -chmod 777 hdfs:/user/spark/applicationHistory

--- a/hadoop-resources/setup-scripts/start/start-master.sh
+++ b/hadoop-resources/setup-scripts/start/start-master.sh
@@ -32,4 +32,5 @@ sudo service hive-metastore restart
 
 #Spark history server
 sudo hdfs dfs -mkdir -p hdfs:///user/spark/applicationHistory
-sudo hdfs dfs -chmod 777 hdfs:/user/spark/applicationHistory
+sudo -u hdfs hadoop fs -chown -R spark:spark /user/spark
+sudo hdfs dfs -chmod 1777 hdfs:/user/spark/applicationHistory

--- a/hadoop-resources/setup-scripts/ubuntu/setup-master.sh
+++ b/hadoop-resources/setup-scripts/ubuntu/setup-master.sh
@@ -108,6 +108,14 @@ echo "GRANT ALL PRIVILEGES ON metastore.* TO 'hive'@localhost;" | sudo tee --app
 echo "FLUSH PRIVILEGES;" | sudo tee --append create-metastore.sql
 sudo mv create-metastore.sql /usr/lib/hive/scripts/metastore/upgrade/mysql/create-metastore.sql
 
+#install spark
+echo "Installing spark..."
+sudo apt-get -y install spark-core spark-history-server spark-python
+
+#configure hive on spark
+cd /usr/lib/hive/lib
+sudo ln -s /usr/lib/spark/lib/spark-assembly.jar spark-assembly.jar
+
 #we disabled start earlier of the services.
 sudo service mysql start
 

--- a/hadoop-resources/setup-scripts/ubuntu/setup-master.sh
+++ b/hadoop-resources/setup-scripts/ubuntu/setup-master.sh
@@ -112,10 +112,6 @@ sudo mv create-metastore.sql /usr/lib/hive/scripts/metastore/upgrade/mysql/creat
 echo "Installing spark..."
 sudo apt-get -y install spark-core spark-history-server spark-python
 
-#configure hive on spark
-cd /usr/lib/hive/lib
-sudo ln -s /usr/lib/spark/lib/spark-assembly.jar spark-assembly.jar
-
 #we disabled start earlier of the services.
 sudo service mysql start
 


### PR DESCRIPTION
This PR adds the spark installation to the AWS cluster created by the `create-aws` command. This allows the use of Hive on Spark, and the corresponding properties have thus been added to the hive site config.