### PR TITLE
Add get-source-summary action

### DIFF
--- a/src/main/scala/com/criteo/dev/cluster/CommandRegistry.scala
+++ b/src/main/scala/com/criteo/dev/cluster/CommandRegistry.scala
@@ -2,6 +2,7 @@ package com.criteo.dev.cluster
 
 import com.criteo.dev.cluster.aws._
 import com.criteo.dev.cluster.docker._
+import com.criteo.dev.cluster.source.GetSourceSummaryCliAction
 import com.criteo.dev.cluster.s3._
 
 /**
@@ -66,7 +67,10 @@ object CommandRegistry {
     Some(GeneralConstants.s3Type))
 
 
-  private val miscCommands = new CliActionCategory("Miscellaneous", List[CliAction[_]] (HelpAction))
+  private val miscCommands = new CliActionCategory("Miscellaneous", List[CliAction[_]] (
+    HelpAction,
+    GetSourceSummaryCliAction
+  ))
 
   private val commands = List[CliActionCategory] (
     localCommands,

--- a/src/main/scala/com/criteo/dev/cluster/copy/ListPartitionAction.scala
+++ b/src/main/scala/com/criteo/dev/cluster/copy/ListPartitionAction.scala
@@ -25,7 +25,7 @@ class ListPartitionAction(conf: Map[String, String], node: Node, throttle: Boole
     }
 
     if (partSpec.isDefined && resultList.length == 0) {
-      throw new IllegalArgumentException(s"partspec returns no result: ${partSpec.get}")
+      throw new IllegalArgumentException(s"partspec returns no result: $database.$table ${partSpec.get}")
     }
 
     //Throttle number of partitions.

--- a/src/main/scala/com/criteo/dev/cluster/source/GetFileSizeAction.scala
+++ b/src/main/scala/com/criteo/dev/cluster/source/GetFileSizeAction.scala
@@ -1,0 +1,22 @@
+package com.criteo.dev.cluster.source
+
+import com.criteo.dev.cluster.{Node, SshAction}
+
+case class GetFileSizeAction(
+                               conf: Map[String, String],
+                               node: Node
+                             ) {
+  /**
+    * Get the list of file sizes, given a list of HDFS file locations
+    *
+    * @param locations List of file locations
+    * @return List of file sizes
+    */
+  def apply(locations: List[String]): List[Long] = {
+    SshAction
+      .apply(node, s"hdfs dfs -du -s ${locations.mkString(" ")}", true)
+      .split("\n")
+      .map(_.split(" ").head.toLong)
+      .toList
+  }
+}

--- a/src/main/scala/com/criteo/dev/cluster/source/GetSourceSummaryAction.scala
+++ b/src/main/scala/com/criteo/dev/cluster/source/GetSourceSummaryAction.scala
@@ -1,0 +1,51 @@
+package com.criteo.dev.cluster.source
+
+import com.criteo.dev.cluster.Node
+import com.criteo.dev.cluster.copy.GetMetadataAction
+
+import scala.util.{Failure, Success, Try}
+
+case class GetSourceSummaryAction(conf: Map[String, String], node: Node) {
+  /**
+    * Get the summary with HDFS file info of the source tables
+    *
+    * @return The table information related to HDFS
+    */
+  def apply(): List[Either[InvalidTable, TableHDFSInfo]] = {
+    val getMetadata = new GetMetadataAction(conf, node)
+    val getFileSizes = GetFileSizeAction(conf, node)
+
+    val (validTables, invalidTables) = conf("source.tables")
+      .split(";")
+      .map(_.trim)
+      .map(tableSpec => (tableSpec, Try(getMetadata(tableSpec))))
+      .toList
+      .partition(_._2.isSuccess)
+    val tableAndLocations = validTables
+      .flatMap { case (_, Success(m)) =>
+        if (m.partitions.size > 0)
+          m.partitions.map(p => (m, p.location))
+        else
+          List((m, m.ddl.location.get))
+      }
+    tableAndLocations
+      .zip(getFileSizes(tableAndLocations.map(_._2)))
+      .groupBy { case ((m, _), _) => m }
+      .foldLeft(List.empty[TableHDFSInfo]) { case (acc, (table, results)) =>
+        TableHDFSInfo(
+          table.database,
+          table.ddl.table,
+          results.map(_._2).sum,
+          results.map(r => HDFSFileInfo(
+            r._1._2,
+            r._2
+          )),
+          table.partitions.size
+        ) :: acc
+      }
+      .map(Right(_)) ++
+      invalidTables.map { case (tableSpec, Failure(e)) =>
+        Left(InvalidTable(tableSpec, e.getMessage))
+      }
+  }
+}

--- a/src/main/scala/com/criteo/dev/cluster/source/GetSourceSummaryCliAction.scala
+++ b/src/main/scala/com/criteo/dev/cluster/source/GetSourceSummaryCliAction.scala
@@ -1,0 +1,33 @@
+package com.criteo.dev.cluster.source
+
+import com.criteo.dev.cluster.{CliAction, NodeFactory}
+import org.slf4j.LoggerFactory
+
+object GetSourceSummaryCliAction extends CliAction[List[Either[InvalidTable, TableHDFSInfo]]] {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  override def command: String = "get-source-summary"
+
+  override def usageArgs: List[Any] = List.empty
+
+  override def help: String = "Get summary of source tables"
+
+  override def applyInternal(args: List[String], conf: Map[String, String]): List[Either[InvalidTable, TableHDFSInfo]] = {
+    logger.info("Getting the summary of source tables")
+    val source = NodeFactory.getSourceFromConf(conf)
+    val getSourceSummary = GetSourceSummaryAction(conf, source)
+    val summary = getSourceSummary()
+    printSummary(summary)
+    summary
+  }
+
+  def printSummary(summary: List[Either[InvalidTable, TableHDFSInfo]]): Unit = {
+    println("Source tables summary")
+    summary.foreach {
+      case Left(InvalidTable(input, message)) =>
+        println(s"$input is invalid, reason: $message")
+      case Right(TableHDFSInfo(db, table, size, files, partitions)) =>
+        println(s"$db.$table is available, size: $size Bytes, files: ${files.size}, partitions: $partitions")
+    }
+  }
+}

--- a/src/main/scala/com/criteo/dev/cluster/source/TableHDFSInfo.scala
+++ b/src/main/scala/com/criteo/dev/cluster/source/TableHDFSInfo.scala
@@ -1,0 +1,19 @@
+package com.criteo.dev.cluster.source
+
+case class TableHDFSInfo(
+                          database: String,
+                          table: String,
+                          size: Long,
+                          files: List[HDFSFileInfo],
+                          partitions: Int
+                        )
+
+case class InvalidTable(
+                         input: String,
+                         message: String
+                       )
+
+case class HDFSFileInfo(
+                         path: String,
+                         size: Long
+                       )


### PR DESCRIPTION
- This command can generate a summary of the source tables, with the HDFS file information of each table