### PR TITLE
Improve copy workflow, add sample size option

### DIFF
--- a/src/main/scala/com/criteo/dev/cluster/aws/CopyAwsCliAction.scala
+++ b/src/main/scala/com/criteo/dev/cluster/aws/CopyAwsCliAction.scala
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory
     val target = NodeFactory.getAwsNode(conf, master)
     val source = NodeFactory.getSourceFromConf(conf)
 
-    CopyAllAction(conf, source, target)
+    CopyAllAction(config, conf, source, target)
 
     logger.info(s"Successfully copied to cluster: ${cluster.master.getId}")
     AwsUtilities.printClusterInfo(conf, cluster)

--- a/src/main/scala/com/criteo/dev/cluster/config/SourceConfig.scala
+++ b/src/main/scala/com/criteo/dev/cluster/config/SourceConfig.scala
@@ -11,9 +11,17 @@ case class SourceConfig(
                          gateway: GatewayConfig
                        )
 
+/**
+  * Table config
+  * @param name the name of the table
+  * @param sampleProb the sampling probability
+  * @param sampleSize the sampling size, which overrides the sample prob
+  * @param partitions the list of partitions
+  */
 case class TableConfig(
                         name: String,
                         sampleProb: Option[Double],
+                        sampleSize: Option[Long],
                         partitions: List[List[String]]
                       )
 

--- a/src/main/scala/com/criteo/dev/cluster/config/SourceConfigConverter.scala
+++ b/src/main/scala/com/criteo/dev/cluster/config/SourceConfigConverter.scala
@@ -21,8 +21,10 @@ object SourceConfigConverter {
       "gateway.docker.ports" -> config.gateway.dockerPorts.mkString(",")
     ) ++ {
       // table.sample.prob -> number
+      // table.sample.size -> number
       config.tables.collect {
-        case TableConfig(name, Some(sampleProb), _) => (s"$name.sample.prob", sampleProb.toString)
+        case TableConfig(name, _, Some(sampleSize), _) => (s"$name.sample.size", sampleSize.toString)
+        case TableConfig(name, Some(sampleProb), _, _) => (s"$name.sample.prob", sampleProb.toString)
       }
     } ++ config.gateway.conf.map { case (k, v) => (s"gateway.$k", v) }
   }

--- a/src/main/scala/com/criteo/dev/cluster/config/SourceConfigParser.scala
+++ b/src/main/scala/com/criteo/dev/cluster/config/SourceConfigParser.scala
@@ -24,6 +24,7 @@ object SourceConfigParser {
   def table(config: Config): Result[TableConfig] = (
     config.get[String]("name") ~
     config.get[Option[Double]]("sample.prob") ~
+    config.get[Option[Long]]("sample.size") ~
     config.get[List[List[String]]]("partitions").orElse(Success(List.empty))
   )(TableConfig)
 

--- a/src/main/scala/com/criteo/dev/cluster/copy/CopyConstants.scala
+++ b/src/main/scala/com/criteo/dev/cluster/copy/CopyConstants.scala
@@ -21,6 +21,8 @@ object CopyConstants {
 
   def sampleProb = "sample.prob"
 
+  def sampleSize = "sample.size"
+
   def sourceS3Scheme = "source.s3.hdfs.scheme"
 
   def sourceCopyScheme = "source.copy.scheme"

--- a/src/main/scala/com/criteo/dev/cluster/copy/GetMetadataAction.scala
+++ b/src/main/scala/com/criteo/dev/cluster/copy/GetMetadataAction.scala
@@ -44,7 +44,7 @@ class GetMetadataAction(conf : Map[String, String], node : Node, throttle: Boole
         //4.  Get partition locations as well
         val getPartitionAction = new GetPartitionMetadataAction(conf, node)
         val partitions = getPartitionAction(db, table, createTable, partitionSpecList)
-        TableInfo(db, createTable, partitions)
+        TableInfo(db, createTable.table, createTable, partitions)
       }
       case _ => throw new IllegalArgumentException(s"Cannot parse ${CopyConstants.sourceTables}: $dbTablePartSpec.  " +
         "Make sure it is of form $db.$table $partition, where $partition is optional and of form (part1='val1', part2='val2').")

--- a/src/main/scala/com/criteo/dev/cluster/copy/HiveMetadataInfos.scala
+++ b/src/main/scala/com/criteo/dev/cluster/copy/HiveMetadataInfos.scala
@@ -2,11 +2,14 @@ package com.criteo.dev.cluster.copy
 
 import com.criteo.dev.cluster.utils.ddl.CreateTable
 
-case class TableInfo(database: String, //optional in the ddl
-                     ddl : CreateTable,
-                     partitions: Array[PartitionInfo])
+case class TableInfo(
+                      database: String, //optional in the ddl
+                      name: String,
+                      ddl: CreateTable,
+                      partitions: Array[PartitionInfo]
+                    )
 
-case class PartitionInfo(location: String, partSpec : PartSpec)
+case class PartitionInfo(location: String, partSpec: PartSpec)
 
 case class PartSpec(specs: Array[PartialPartSpec])
 

--- a/src/main/scala/com/criteo/dev/cluster/docker/CopyLocalCliAction.scala
+++ b/src/main/scala/com/criteo/dev/cluster/docker/CopyLocalCliAction.scala
@@ -24,7 +24,7 @@ import com.criteo.dev.cluster.{CliAction, NodeFactory, Public}
     val source = NodeFactory.getSourceFromConf(conf)
 
     //TODO- hack, the docker id should go into "target" Node object, but currently Node does not have sub-classes
-    CopyAllAction(conf + (DockerConstants.localContainerId -> runningDockerMeta(0).id), source, target)
+    CopyAllAction(config, conf + (DockerConstants.localContainerId -> runningDockerMeta(0).id), source, target)
 
     DockerUtilities.printClusterDockerContainerInfo(conf, dockerMeta)
   }

--- a/src/main/scala/com/criteo/dev/cluster/s3/CopyBucketCliAction.scala
+++ b/src/main/scala/com/criteo/dev/cluster/s3/CopyBucketCliAction.scala
@@ -30,6 +30,6 @@ object CopyBucketCliAction extends CliAction[Unit] {
     val source = NodeFactory.getSourceFromConf(conf)
 
     //parse source-tables.
-    CopyAllAction(conf, source, target)
+    CopyAllAction(config, conf, source, target)
   }
 }

--- a/src/main/scala/com/criteo/dev/cluster/source/GetSourceSummaryCliAction.scala
+++ b/src/main/scala/com/criteo/dev/cluster/source/GetSourceSummaryCliAction.scala
@@ -4,7 +4,7 @@ import com.criteo.dev.cluster.config.GlobalConfig
 import com.criteo.dev.cluster.{CliAction, NodeFactory}
 import org.slf4j.LoggerFactory
 
-object GetSourceSummaryCliAction extends CliAction[List[Either[InvalidTable, TableHDFSInfo]]] {
+object GetSourceSummaryCliAction extends CliAction[List[Either[InvalidTable, SourceTableInfo]]] {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   override def command: String = "get-source-summary"
@@ -13,22 +13,22 @@ object GetSourceSummaryCliAction extends CliAction[List[Either[InvalidTable, Tab
 
   override def help: String = "Get summary of source tables"
 
-  override def applyInternal(args: List[String], config: GlobalConfig): List[Either[InvalidTable, TableHDFSInfo]] = {
+  override def applyInternal(args: List[String], config: GlobalConfig): List[Either[InvalidTable, SourceTableInfo]] = {
     val conf = config.backCompat
     logger.info("Getting the summary of source tables")
     val source = NodeFactory.getSourceFromConf(conf)
     val getSourceSummary = GetSourceSummaryAction(config, source)
-    val summary = getSourceSummary()
+    val summary = getSourceSummary(config.source.tables)
     printSummary(summary)
     summary
   }
 
-  def printSummary(summary: List[Either[InvalidTable, TableHDFSInfo]]): Unit = {
+  def printSummary(summary: List[Either[InvalidTable, SourceTableInfo]]): Unit = {
     println("Source tables summary")
     summary.foreach {
       case Left(InvalidTable(input, message)) =>
         println(s"$input is invalid, reason: $message")
-      case Right(TableHDFSInfo(db, table, size, files, partitions)) =>
+      case Right(SourceTableInfo(_, TableHDFSInfo(db, table, size, files, partitions))) =>
         println(s"$db.$table is available, size: $size Bytes, files: ${files.size}, partitions: $partitions")
     }
   }

--- a/src/main/scala/com/criteo/dev/cluster/source/SourceTableInfo.scala
+++ b/src/main/scala/com/criteo/dev/cluster/source/SourceTableInfo.scala
@@ -1,0 +1,8 @@
+package com.criteo.dev.cluster.source
+
+import com.criteo.dev.cluster.copy.TableInfo
+
+case class SourceTableInfo(
+                            tableInfo: TableInfo,
+                            hdfsInfo: TableHDFSInfo
+                          )

--- a/src/test/resources/source_test.conf
+++ b/src/test/resources/source_test.conf
@@ -1,14 +1,16 @@
-address = jobs-user.pa4.hpc.criteo.prod
+address = dev.cluster
 tables = [
   {
-    name = bi_datamart.bi_dim_affiliate
+    name = log.t1
     sample.prob = 0.02
     partitions = [
       ["day='2017-05-01'","platform=2"]
     ]
   },
   {
-    name = bi_datamart.bi_dim_budget
+    name = log.t2
+    sample.prob = 0.1
+    sample.size = 500
   }
 ]
 s3.hdfs.scheme = s3a

--- a/src/test/scala/com.criteo.dev.cluster/config/SourceConfigParserSpec.scala
+++ b/src/test/scala/com.criteo.dev.cluster/config/SourceConfigParserSpec.scala
@@ -21,9 +21,11 @@ class SourceConfigParserSpec extends FlatSpec with Matchers {
       conf.productArity - 1 +
       conf.copyConfig.productArity - 1 +
       conf.gateway.productArity - 1 +
+      conf.gateway.conf.size - 1 +
       conf.tables.filter(_.sampleProb.isDefined).size +
-      conf.gateway.conf.size
+      conf.tables.filter(_.sampleSize.isDefined).size
     )
     res.size shouldEqual size
+    res.get("log.t2.sample.size") shouldBe Some("500")
   }
 }


### PR DESCRIPTION
- add sample.size option for each source table
- copy actions will fetch the table metadata first, then copy the data and gathers the failures