### PR TITLE
Generate checkpoints when copying

### DIFF
--- a/src/main/scala/com/criteo/dev/cluster/aws/CopyAwsCliAction.scala
+++ b/src/main/scala/com/criteo/dev/cluster/aws/CopyAwsCliAction.scala
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory
 
   override def usageArgs: List[Any] = List("cluster.id")
 
-  override def help: String = "Copies sample data from gateway to AWS cluster identified by cluster.id"
+  override def help: String = "Copies sample data from gateway to AWS cluster identified by cluster.id, the copy progress can be restored with --checkpoint=<checkpoint file> option"
 
   override def applyInternal(args: List[String], config: GlobalConfig): Unit = {
     //find the ip

--- a/src/main/scala/com/criteo/dev/cluster/config/Checkpoint.scala
+++ b/src/main/scala/com/criteo/dev/cluster/config/Checkpoint.scala
@@ -1,0 +1,11 @@
+package com.criteo.dev.cluster.config
+
+import java.time.Instant
+
+case class Checkpoint(
+                       created: Instant,
+                       updated: Instant,
+                       todo: Set[String] = Set.empty,
+                       finished: Set[String] = Set.empty,
+                       failed: Set[String] = Set.empty
+                     )

--- a/src/main/scala/com/criteo/dev/cluster/config/CheckpointParser.scala
+++ b/src/main/scala/com/criteo/dev/cluster/config/CheckpointParser.scala
@@ -1,0 +1,18 @@
+package com.criteo.dev.cluster.config
+
+import java.time.Instant
+
+import com.typesafe.config.Config
+import configs.Result
+import configs.syntax._
+
+object CheckpointParser {
+  def apply(config: Config): Result[Checkpoint] =
+    (
+      config.get[Long]("created").map(Instant.ofEpochMilli(_)) ~
+      config.get[Long]("updated").map(Instant.ofEpochMilli(_)) ~
+      config.get[Set[String]]("todo") ~
+      config.get[Set[String]]("finished") ~
+      config.get[Set[String]]("failed")
+    )(Checkpoint)
+}

--- a/src/main/scala/com/criteo/dev/cluster/config/CheckpointWriter.scala
+++ b/src/main/scala/com/criteo/dev/cluster/config/CheckpointWriter.scala
@@ -1,0 +1,21 @@
+package com.criteo.dev.cluster.config
+
+import com.typesafe.config.{Config, ConfigFactory, ConfigRenderOptions, ConfigValueFactory}
+
+import collection.JavaConverters._
+
+object CheckpointWriter {
+  def apply(checkpoint: Checkpoint): Config = {
+    import checkpoint._
+    ConfigFactory.empty
+      .withValue("created", ConfigValueFactory.fromAnyRef(created.toEpochMilli))
+      .withValue("updated", ConfigValueFactory.fromAnyRef(updated.toEpochMilli))
+      .withValue("todo", ConfigValueFactory.fromIterable(todo.asJava))
+      .withValue("finished", ConfigValueFactory.fromIterable(finished.asJava))
+      .withValue("failed", ConfigValueFactory.fromIterable(failed.asJava))
+  }
+
+  def render(checkpoint: Checkpoint, configRenderOptions: ConfigRenderOptions = ConfigRenderOptions.concise): String = {
+    apply(checkpoint).root.render(configRenderOptions)
+  }
+}

--- a/src/main/scala/com/criteo/dev/cluster/config/ConfigLoader.scala
+++ b/src/main/scala/com/criteo/dev/cluster/config/ConfigLoader.scala
@@ -3,21 +3,30 @@ package com.criteo.dev.cluster.config
 import java.net.URL
 
 import com.criteo.dev.cluster.Public
-import com.typesafe.config.{Config, ConfigFactory, ConfigParseOptions, ConfigResolveOptions}
+import com.typesafe.config.{Config, ConfigFactory}
 import configs.Result
+import configs.Result.Success
 import configs.syntax._
 
 @Public
 object ConfigLoader {
-  def apply(source: URL, target: URL): Result[GlobalConfig] = apply(
+  def apply(
+             source: URL,
+             target: URL,
+             checkpoint: Option[URL]
+           ): Result[GlobalConfig] = apply(
     ConfigFactory.parseURL(source).resolve(),
-    ConfigFactory.parseURL(target).resolve()
+    ConfigFactory.parseURL(target).resolve(),
+    checkpoint.map(ConfigFactory.parseURL(_).resolve)
   )
 
-  def apply(source: Config, target: Config): Result[GlobalConfig] = (
+  def apply(
+             source: Config,
+             target: Config,
+             checkpoint: Option[Config]
+           ): Result[GlobalConfig] = (
     SourceConfigParser(source) ~
-    TargetConfigParser(target)
-  )(GlobalConfig(_,_)).map(_.withBackCompat)
-
-
+    TargetConfigParser(target) ~
+    checkpoint.fold(Success(None): Result[Option[Checkpoint]])(CheckpointParser.apply(_).map(Some(_)))
+  )(GlobalConfig(_,_,_)).map(_.withBackCompat)
 }

--- a/src/main/scala/com/criteo/dev/cluster/config/GlobalConfig.scala
+++ b/src/main/scala/com/criteo/dev/cluster/config/GlobalConfig.scala
@@ -3,11 +3,13 @@ package com.criteo.dev.cluster.config
 case class GlobalConfig(
                          source: SourceConfig,
                          target: TargetConfig,
+                         checkpoint: Option[Checkpoint],
                          backCompat: Map[String, String] = Map.empty
                        ) {
   def withBackCompat() = GlobalConfig(
     source,
     target,
+    checkpoint,
     SourceConfigConverter(source) ++ TargetConfigConverter(target)
   )
 }

--- a/src/main/scala/com/criteo/dev/cluster/copy/HiveMetadataInfos.scala
+++ b/src/main/scala/com/criteo/dev/cluster/copy/HiveMetadataInfos.scala
@@ -7,7 +7,9 @@ case class TableInfo(
                       name: String,
                       ddl: CreateTable,
                       partitions: Array[PartitionInfo]
-                    )
+                    ) {
+  def fullName = s"$database.$name"
+}
 
 case class PartitionInfo(location: String, partSpec: PartSpec)
 

--- a/src/main/scala/com/criteo/dev/cluster/docker/CopyLocalCliAction.scala
+++ b/src/main/scala/com/criteo/dev/cluster/docker/CopyLocalCliAction.scala
@@ -33,6 +33,6 @@ import com.criteo.dev.cluster.{CliAction, NodeFactory, Public}
 
   override def usageArgs: List[Any] = List("container.id")
 
-  override def help: String = "Copies sample data from gateway to node identified by container.id"
+  override def help: String = "Copies sample data from gateway to node identified by container.id, the copy progress can be restored with --checkpoint=<checkpoint file> option"
 
 }

--- a/src/main/scala/com/criteo/dev/cluster/source/GetSourceSummaryCliAction.scala
+++ b/src/main/scala/com/criteo/dev/cluster/source/GetSourceSummaryCliAction.scala
@@ -26,8 +26,8 @@ object GetSourceSummaryCliAction extends CliAction[List[Either[InvalidTable, Sou
   def printSummary(summary: List[Either[InvalidTable, SourceTableInfo]]): Unit = {
     println("Source tables summary")
     val (invalid, valid) = summary.partition(_.isLeft)
-    invalid.map(_.left.get).foreach { case InvalidTable(input, message) =>
-      println(s"$input is invalid, reason: $message")
+    invalid.map(_.left.get).foreach { case InvalidTable(name, input, message) =>
+      println(s"$name is invalid, input: $input, reason: $message")
     }
     valid.map(_.right.get) foreach { case SourceTableInfo(_, TableHDFSInfo(db, table, size, files, partitions)) =>
       println(s"$db.$table is available, size: $size Bytes, files: ${files.size}, partitions: $partitions")

--- a/src/main/scala/com/criteo/dev/cluster/source/TableHDFSInfo.scala
+++ b/src/main/scala/com/criteo/dev/cluster/source/TableHDFSInfo.scala
@@ -9,6 +9,7 @@ case class TableHDFSInfo(
                         )
 
 case class InvalidTable(
+                         name: String,
                          input: String,
                          message: String
                        )

--- a/src/test/resources/checkpoint_test.conf
+++ b/src/test/resources/checkpoint_test.conf
@@ -1,0 +1,12 @@
+created = 1000
+updated = 2000
+finished = [
+  "db.t1",
+  "db.t2"
+]
+failed = [
+  "db.t0"
+]
+todo = [
+  "db.t3",
+]

--- a/src/test/scala/com.criteo.dev.cluster/config/CheckpointParserSpec.scala
+++ b/src/test/scala/com.criteo.dev.cluster/config/CheckpointParserSpec.scala
@@ -1,0 +1,17 @@
+package com.criteo.dev.cluster.config
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{FlatSpec, Matchers}
+
+class CheckpointParserSpec extends FlatSpec with Matchers {
+  val config = ConfigFactory.load("checkpoint_test")
+  "apply" should "parse a checkpoint" in {
+    val res = CheckpointParser(config)
+    res.isSuccess shouldBe true
+    res.value.created.toEpochMilli shouldEqual 1000
+    res.value.updated.toEpochMilli shouldEqual 2000
+    res.value.finished shouldEqual Set("db.t1", "db.t2")
+    res.value.todo shouldEqual Set("db.t3")
+    res.value.failed shouldEqual Set("db.t0")
+  }
+}

--- a/src/test/scala/com.criteo.dev.cluster/config/CheckpointWriterSpec.scala
+++ b/src/test/scala/com.criteo.dev.cluster/config/CheckpointWriterSpec.scala
@@ -1,0 +1,20 @@
+package com.criteo.dev.cluster.config
+
+import java.time.Instant
+
+import com.typesafe.config.ConfigRenderOptions
+import org.scalatest.{FlatSpec, Matchers}
+
+class CheckpointWriterSpec extends FlatSpec with Matchers {
+  "apply" should "convert a Checkpoint to a Config" in {
+    val checkpoint = Checkpoint(
+      Instant.ofEpochMilli(1000),
+      Instant.ofEpochMilli(2000),
+      Set("db.t1"),
+      Set("db.t2"),
+      Set("db.t3")
+    )
+    val res = CheckpointWriter(checkpoint).root.render(ConfigRenderOptions.concise)
+    res shouldEqual """{"created":1000,"failed":["db.t3"],"finished":["db.t2"],"todo":["db.t1"],"updated":2000}"""
+  }
+}

--- a/src/test/scala/com.criteo.dev.cluster/utils/test/LoadConfig.scala
+++ b/src/test/scala/com.criteo.dev.cluster/utils/test/LoadConfig.scala
@@ -1,15 +1,12 @@
 package com.criteo.dev.cluster.utils.test
 
-import java.io.File
-import java.net.URL
-import java.nio.file.Paths
-
 import com.criteo.dev.cluster.config.ConfigLoader
 
 trait LoadConfig {
   val config = ConfigLoader(
     ClassLoader.getSystemResource("source_test.conf").toURI.toURL,
-    ClassLoader.getSystemResource("target_test.conf").toURI.toURL
+    ClassLoader.getSystemResource("target_test.conf").toURI.toURL,
+    None
   ).value
 
   val conf = config.backCompat


### PR DESCRIPTION
- Checkpoint files are created and updated after each table has been copied, they can be used to restore the copying progress