### PR TITLE
missing access key should not crash the program

### DIFF
--- a/conf/target.conf
+++ b/conf/target.conf
@@ -44,9 +44,11 @@ aws {
   //This is determined by the base Ubuntu image(s) specified in base.image.id.
   user = ubuntu
 
-  access.id = ${AWS_ACCESS_ID}
-  
-  access.key = ${AWS_ACCESS_KEY}
+  access.id = "id"
+  access.id = ${?AWS_ACCESS_ID}
+
+  access.key = "key"
+  access.key = ${?AWS_ACCESS_KEY}
 
   //Instance type to use in dev cluster.
   instance.type = m4.2xlarge


### PR DESCRIPTION
- make access key optional as some functionalities don't depend on it