### PR TITLE
Use a temp file for each Hive/Shell action

### DIFF
--- a/src/main/scala/com/criteo/dev/cluster/GeneralUtilities.scala
+++ b/src/main/scala/com/criteo/dev/cluster/GeneralUtilities.scala
@@ -27,14 +27,16 @@ object GeneralUtilities {
 
   def getTempDir(): String = {
     if (tempDir.get == null)
-      tempDir.set {
-        val date = DateTimeFormatter
-          .ofPattern("yyyyMMdd-HHmmss")
-          .withZone(ZoneId.systemDefault())
-          .format(Instant.now)
-        s"./temp-$date-thread-${Thread.currentThread.getId}"
-      }
+      tempDir.set(s"./$getTempPrefix")
     tempDir.get
+  }
+
+  def getTempPrefix(): String = {
+    val date = DateTimeFormatter
+      .ofPattern("yyyyMMdd-HHmmss")
+      .withZone(ZoneId.systemDefault())
+      .format(Instant.now)
+    s"temp-$date-thread-${Thread.currentThread.getId}"
   }
 
   def prepareDir(dir: String) = {

--- a/src/main/scala/com/criteo/dev/cluster/command/ShellHiveAction.scala
+++ b/src/main/scala/com/criteo/dev/cluster/command/ShellHiveAction.scala
@@ -12,18 +12,17 @@ import scala.collection.mutable.ListBuffer
   */
 @Public
 class ShellHiveAction(ignoreError: Boolean = false) extends HiveAction {
-  private final val localTmpQueryFile = s"${GeneralUtilities.getTempDir}/tmphivequery"
-
   private val commands = new ListBuffer[String]
   private val logger = LoggerFactory.getLogger(this.getClass)
+
+  private final val filepath = s"${GeneralUtilities.getHomeDir}/${GeneralUtilities.getTempPrefix}-hivequery"
 
   def add(action: String): Unit = {
     commands += action
   }
 
   def run(): String = {
-    GeneralUtilities.prepareTempDir
-    val localQueryFile = new File(s"${GeneralUtilities.getHomeDir}/$localTmpQueryFile")
+    val localQueryFile = new File(filepath)
     val writer = new PrintWriter(localQueryFile)
     commands.foreach(s => {
       writer.write(s"$s;\n")
@@ -36,8 +35,6 @@ class ShellHiveAction(ignoreError: Boolean = false) extends HiveAction {
     localQueryFile.deleteOnExit()
 
     val ignoreErrorFlag = if (ignoreError) "-hiveconf hive.cli.errors.ignore=true" else ""
-    val ret = ShellAction(s"hive $ignoreErrorFlag -f $localTmpQueryFile", returnResult = true, ignoreError)
-    GeneralUtilities.cleanupTempDir
-    ret
+    ShellAction(s"hive $ignoreErrorFlag -f $filepath", returnResult = true, ignoreError)
   }
 }

--- a/src/main/scala/com/criteo/dev/cluster/command/ShellMultiAction.scala
+++ b/src/main/scala/com/criteo/dev/cluster/command/ShellMultiAction.scala
@@ -17,17 +17,15 @@ case class ShellMultiAction() extends MultiAction {
   private val commands = new ListBuffer[String]
 
   //to allow concurrency
-  val localTmpShell = s"${GeneralUtilities.getTempDir}-tmp.sh"
+  val filepath = s"${GeneralUtilities.getHomeDir}/${GeneralUtilities.getTempPrefix}.sh"
 
   def add(command: String): Unit = {
     commands.+=(command)
   }
 
   def run(returnResult: Boolean = false, ignoreError: Boolean = false): String = {
-    //cleanup tmp files, ignore errors in these commands.
-    GeneralUtilities.prepareTempDir
-    val localTmpShellFile = new File(s"${GeneralUtilities.getHomeDir}/$localTmpShell")
-    ShellAction("rm " + localTmpShell, returnResult = false, true)
+    val localTmpShellFile = new File(filepath)
+    ShellAction(s"rm $filepath", returnResult = false, true)
 
     //Write a temp shell script
     val writer = new PrintWriter(localTmpShellFile)
@@ -36,11 +34,10 @@ case class ShellMultiAction() extends MultiAction {
 
     localTmpShellFile.setExecutable(true)
     localTmpShellFile.setReadable(true)
+    localTmpShellFile.deleteOnExit()
 
     commands.foreach(s => logger.info(s))
-    val res = ShellAction(localTmpShell, returnResult, ignoreError)
-    localTmpShellFile.delete()
-    res
+    ShellAction(filepath, returnResult, ignoreError)
   }
 }
 

--- a/src/main/scala/com/criteo/dev/cluster/s3/LocalRsyncCopyAction.scala
+++ b/src/main/scala/com/criteo/dev/cluster/s3/LocalRsyncCopyAction.scala
@@ -30,7 +30,9 @@ class LocalRsyncCopyAction(config: GlobalConfig, source: Node, target: Node) ext
     copy(tempDir)
     put(tempDir, sourceFiles, sourceBase, targetBase)
 
+    // clean up
     deleteTargetTmpDir(target)
+    GeneralUtilities.cleanupTempDir
   }
 
   /**


### PR DESCRIPTION
- Hive/Shell scripts are separated from the temp dirs in which temp data are put, and each thread has a unique file name