### PR TITLE
Update shell/ssh actions

### DIFF
--- a/src/main/scala/com/criteo/dev/cluster/GeneralUtilities.scala
+++ b/src/main/scala/com/criteo/dev/cluster/GeneralUtilities.scala
@@ -31,10 +31,10 @@ object GeneralUtilities {
     tempDir.get
   }
 
-  def getTempPrefix(): String = s"temp_${getSimpleDate}_thread_${Thread.currentThread.getId}"
+  def getTempPrefix(): String = s"temp_${getSimpleDate}_${Thread.currentThread.getName}"
 
   def getSimpleDate(): String = DateTimeFormatter
-    .ofPattern("yyyyMMdd_HHmmss")
+    .ofPattern("yyyyMMdd_HHmmss_SSS")
     .withZone(ZoneId.systemDefault())
     .format(Instant.now)
 

--- a/src/main/scala/com/criteo/dev/cluster/command/ShellHiveAction.scala
+++ b/src/main/scala/com/criteo/dev/cluster/command/ShellHiveAction.scala
@@ -35,6 +35,8 @@ class ShellHiveAction(ignoreError: Boolean = false) extends HiveAction {
     localQueryFile.deleteOnExit()
 
     val ignoreErrorFlag = if (ignoreError) "-hiveconf hive.cli.errors.ignore=true" else ""
-    ShellAction(s"hive $ignoreErrorFlag -f $filepath", returnResult = true, ignoreError)
+    val res = ShellAction(s"hive $ignoreErrorFlag -f $filepath", returnResult = true, ignoreError)
+    localQueryFile.delete()
+    res
   }
 }

--- a/src/main/scala/com/criteo/dev/cluster/command/ShellMultiAction.scala
+++ b/src/main/scala/com/criteo/dev/cluster/command/ShellMultiAction.scala
@@ -37,7 +37,9 @@ case class ShellMultiAction() extends MultiAction {
     localTmpShellFile.deleteOnExit()
 
     commands.foreach(s => logger.info(s))
-    ShellAction(filepath, returnResult, ignoreError)
+    val res = ShellAction(filepath, returnResult, ignoreError)
+    localTmpShellFile.delete()
+    res
   }
 }
 

--- a/src/main/scala/com/criteo/dev/cluster/command/SshHiveAction.scala
+++ b/src/main/scala/com/criteo/dev/cluster/command/SshHiveAction.scala
@@ -40,9 +40,10 @@ class SshHiveAction(node: Node, ignoreError: Boolean = false) extends HiveAction
     ScpAction(None, localFilepath, Some(node), remoteFilepath)
     val ignoreErrorFlag = if (ignoreError) "-hiveconf hive.cli.errors.ignore=true" else ""
 
-    val ret = SshAction(node, s"hive $ignoreErrorFlag -f $remoteFilepath", returnResult = true, ignoreError)
+    val res = SshAction(node, s"hive $ignoreErrorFlag -f $remoteFilepath", returnResult = true, ignoreError)
     SshAction(node, s"rm $remoteFilepath")
-    ret
+    localQueryFile.delete()
+    res
   }
 
   override def toString = {

--- a/src/main/scala/com/criteo/dev/cluster/command/SshMultiAction.scala
+++ b/src/main/scala/com/criteo/dev/cluster/command/SshMultiAction.scala
@@ -43,9 +43,10 @@ case class SshMultiAction(node: Node) extends MultiAction {
     commands.foreach(s => logger.info(s))
 
     ScpAction(None, localFilepath, Some(node), remoteFilePath)
-    val result = SshAction(node, s"source $remoteFilePath", returnResult, ignoreError)
+    val res = SshAction(node, s"source $remoteFilePath", returnResult, ignoreError)
     SshAction(node, s"rm $remoteFilePath", returnResult = false, true)
-    result
+    localTmpShellFile.delete()
+    res
   }
 }
 


### PR DESCRIPTION
- Use thread name as part of file name
- Each execution cleans up its generated script file